### PR TITLE
158-update-windows-node-installation-instruction

### DIFF
--- a/Section00/0.1.2-ForWindowsUsers.md
+++ b/Section00/0.1.2-ForWindowsUsers.md
@@ -12,7 +12,8 @@
    - on the "**Choosing the default editor used by Git**" page, select "Use Visual Studio Code as Git's default editor"
    - on the "**Adjusting your PATH environment**" page, select the recommended middle option: "Git from the command line and also from 3rd-party software"
    - on the "**Configuring the line ending conversions**" page, select the middle option: "Checkout as-is, commit Unix-style line endings
-5. Download and install [Node](https://nodejs.org/en/download/)
+5. Download and install [Node LTS 64bit](https://nodejs.org/en/)
+   - be sure to select "LTS" version on the left, NOT "Current" version on the right, when downloading the installer
    - when installing, **all** default settings are fine
 6. Check that you have installed everything correctly by running the following commands in your terminal:
    - `node -v`


### PR DESCRIPTION
Altered the Node JS download link in 0.1.2 as well as link text. Added a second bullet point before the existing note about option selection during download to reinforce to users to choose LTS, NOT Current version of Node.