### PR TITLE
Update 3.1-Functions.md

### DIFF
--- a/Section03/3.1-Functions.md
+++ b/Section03/3.1-Functions.md
@@ -362,11 +362,11 @@ In a concise body, only an expression is specified, which becomes the implicit r
 
 ```javascript
 // concise body
-const greet = (n) => "Hello ${n}";
+const greet = (n) => `Hello ${n}`;
 
 // block body
 const greet = (n) => {
-  return "Hello ${n}";
+  return `Hello ${n}`;
 };
 ```
 


### PR DESCRIPTION
Fixing Template Literals to have backticks instead of quotation marks