### PR TITLE
Fixing Typos in 4.2

### DIFF
--- a/Section04/4.2-ArrayMethods1.md
+++ b/Section04/4.2-ArrayMethods1.md
@@ -71,14 +71,14 @@ const str = "JavaScript is amazing";
 console.log(str.toLowerCase()); // 'javascript is amazing'
 ```
 
-### **3) `.indexOf()` & `lastIndexOf()`**
+### **3) `.indexOf()` & `.lastIndexOf()`**
 
 - `.indexOf()` - returns the index in the string of the 1st occurrence of the specified value, starting the search at `fromIndex` parameter. Returns -1 if the value is not found.
 
-- `lastIndexOf()` -The lastIndexOf() method returns the index within the calling String object of the last occurrence of the specified value, searching backwards from fromIndex. Returns -1 if the value is not found.
+- `.lastIndexOf()` -The lastIndexOf() method returns the index within the calling String object of the last occurrence of the specified value, searching backwards from fromIndex. Returns -1 if the value is not found.
 
 ```javascript
-// .indexOf() - returns the index of the 1st occurrence of a value
+// indexOf() - returns the index of the 1st occurrence of a value
 const paragraph =
   "The quick brown fox jumps over the lazy dog. If the dog barked, was it really lazy?";
 


### PR DESCRIPTION
Fixing Typos to .lastIndexOf() where the . was missing and not uniform with other methods listed in this section