### PR TITLE
Added Note Explaining Unshift parameter difference

### DIFF
--- a/Section04/4.2-ArrayMethods1.md
+++ b/Section04/4.2-ArrayMethods1.md
@@ -237,6 +237,8 @@ console.log(arr);
 // [-1, 1, 2, 3, 5]
 ```
 
+> **NOTE**: If multiple elements are passed as parameters for .unshift(), they're inserted in chunk at the beginning of the object, in the exact same order they were passed as parameters. For an example, see this [unshift() documentation from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift#description).
+
 <br>
 
 ---


### PR DESCRIPTION
Added this note below unshift example

`> **NOTE**: If multiple elements are passed as parameters for .unshift(), they're inserted in chunk at the beginning of the object, in the exact same order they were passed as parameters. For an example, see this [unshift() documentation from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift#description).`