### PR TITLE
349 update activity instructions to refer to correct repo

### DIFF
--- a/Section02/Activities/2.3-Activities/2.3.1-MathOperatorsAndDataCoercionIntro.md
+++ b/Section02/Activities/2.3-Activities/2.3.1-MathOperatorsAndDataCoercionIntro.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your Class Activities repo

--- a/Section02/Activities/2.3-Activities/2.3.2-ComparisonOperatorsAndIfElseStatements.md
+++ b/Section02/Activities/2.3-Activities/2.3.2-ComparisonOperatorsAndIfElseStatements.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your Class Activities repo

--- a/Section02/Activities/2.3-Activities/2.3.3-SwitchStatements.md
+++ b/Section02/Activities/2.3-Activities/2.3.3-SwitchStatements.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your Class Activities repo

--- a/Section02/Activities/2.3-Activities/2.3.4-TruthyFalsyAndLogicalOperators.md
+++ b/Section02/Activities/2.3-Activities/2.3.4-TruthyFalsyAndLogicalOperators.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your Class Activities repo

--- a/Section02/Activities/2.3-Activities/2.3.5-Loops.md
+++ b/Section02/Activities/2.3-Activities/2.3.5-Loops.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your Class Activities repo

--- a/Section03/Activities/3.1-Activities/3.1.1-FunctionDeclaration.md
+++ b/Section03/Activities/3.1-Activities/3.1.1-FunctionDeclaration.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.1.1-FunctionDeclaration.js`

--- a/Section03/Activities/3.1-Activities/3.1.1-FunctionDeclaration.md
+++ b/Section03/Activities/3.1-Activities/3.1.1-FunctionDeclaration.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.1-Activities/3.1.2-FunctionInvovation.md
+++ b/Section03/Activities/3.1-Activities/3.1.2-FunctionInvovation.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.1.2-FunctionInvocation.js`

--- a/Section03/Activities/3.1-Activities/3.1.2-FunctionInvovation.md
+++ b/Section03/Activities/3.1-Activities/3.1.2-FunctionInvovation.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.1-Activities/3.1.3-ReturnsAndShortCircuiting.md
+++ b/Section03/Activities/3.1-Activities/3.1.3-ReturnsAndShortCircuiting.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.1.3-ReturnsAndShortCircuiting.js`

--- a/Section03/Activities/3.1-Activities/3.1.3-ReturnsAndShortCircuiting.md
+++ b/Section03/Activities/3.1-Activities/3.1.3-ReturnsAndShortCircuiting.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.1-Activities/3.1.4-Parameters.md
+++ b/Section03/Activities/3.1-Activities/3.1.4-Parameters.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.1.4-Parameters.js`

--- a/Section03/Activities/3.1-Activities/3.1.4-Parameters.md
+++ b/Section03/Activities/3.1-Activities/3.1.4-Parameters.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.1-Activities/3.1.5-FunctionsAndScope.md
+++ b/Section03/Activities/3.1-Activities/3.1.5-FunctionsAndScope.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.1.5-FunctionsAndScope.js`

--- a/Section03/Activities/3.1-Activities/3.1.5-FunctionsAndScope.md
+++ b/Section03/Activities/3.1-Activities/3.1.5-FunctionsAndScope.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.1-Activities/3.1.6-Callbacks.md
+++ b/Section03/Activities/3.1-Activities/3.1.6-Callbacks.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.1.6-Callbacks.js`

--- a/Section03/Activities/3.1-Activities/3.1.6-Callbacks.md
+++ b/Section03/Activities/3.1-Activities/3.1.6-Callbacks.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.1-Activities/3.1.7-ArrowSyntax.md
+++ b/Section03/Activities/3.1-Activities/3.1.7-ArrowSyntax.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.1.7-ArrowSyntax.js`

--- a/Section03/Activities/3.1-Activities/3.1.7-ArrowSyntax.md
+++ b/Section03/Activities/3.1-Activities/3.1.7-ArrowSyntax.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.2-Activities/3.2.1-Arrays.md
+++ b/Section03/Activities/3.2-Activities/3.2.1-Arrays.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.2.1-Arrays.js`

--- a/Section03/Activities/3.2-Activities/3.2.1-Arrays.md
+++ b/Section03/Activities/3.2-Activities/3.2.1-Arrays.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.2-Activities/3.2.2-MorePracticeWithObjects.md
+++ b/Section03/Activities/3.2-Activities/3.2.2-MorePracticeWithObjects.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your activities Repo, then this week's activities

--- a/Section03/Activities/3.2-Activities/3.2.3-Mutation.md
+++ b/Section03/Activities/3.2-Activities/3.2.3-Mutation.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.2.3-Mutation.js`

--- a/Section03/Activities/3.2-Activities/3.2.3-Mutation.md
+++ b/Section03/Activities/3.2-Activities/3.2.3-Mutation.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section03/Activities/3.2-Activities/3.2.4-ReferenceAndValue.md
+++ b/Section03/Activities/3.2-Activities/3.2.4-ReferenceAndValue.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `3.2.4-ReferenceAndValue.js`

--- a/Section03/Activities/3.2-Activities/3.2.4-ReferenceAndValue.md
+++ b/Section03/Activities/3.2-Activities/3.2.4-ReferenceAndValue.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.1-Activities/4.1.1-SelectingDOMElements.md
+++ b/Section04/Activities/4.1-Activities/4.1.1-SelectingDOMElements.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.1.1-SelectingDOMElements.js`

--- a/Section04/Activities/4.1-Activities/4.1.1-SelectingDOMElements.md
+++ b/Section04/Activities/4.1-Activities/4.1.1-SelectingDOMElements.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.1-Activities/4.1.2-NodeRelationships.md
+++ b/Section04/Activities/4.1-Activities/4.1.2-NodeRelationships.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.1.2-NodeRelationships.js`

--- a/Section04/Activities/4.1-Activities/4.1.2-NodeRelationships.md
+++ b/Section04/Activities/4.1-Activities/4.1.2-NodeRelationships.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.1-Activities/4.1.3-ChangingElements.md
+++ b/Section04/Activities/4.1-Activities/4.1.3-ChangingElements.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.1.3-ChangingElements.js`

--- a/Section04/Activities/4.1-Activities/4.1.3-ChangingElements.md
+++ b/Section04/Activities/4.1-Activities/4.1.3-ChangingElements.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.1-Activities/4.1.4-CreatingElements.md
+++ b/Section04/Activities/4.1-Activities/4.1.4-CreatingElements.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.1.4-CreatingElements.js`

--- a/Section04/Activities/4.1-Activities/4.1.4-CreatingElements.md
+++ b/Section04/Activities/4.1-Activities/4.1.4-CreatingElements.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.1-Activities/4.1.5-EventListeners.md
+++ b/Section04/Activities/4.1-Activities/4.1.5-EventListeners.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.1.5-EventListeners.js`

--- a/Section04/Activities/4.1-Activities/4.1.5-EventListeners.md
+++ b/Section04/Activities/4.1-Activities/4.1.5-EventListeners.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.2-Activities/4.2.1-PopPushShiftUnshift.md
+++ b/Section04/Activities/4.2-Activities/4.2.1-PopPushShiftUnshift.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.2.1-PopPushShiftUnshift.js`

--- a/Section04/Activities/4.2-Activities/4.2.1-PopPushShiftUnshift.md
+++ b/Section04/Activities/4.2-Activities/4.2.1-PopPushShiftUnshift.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.2-Activities/4.2.2-LocatingSliceSplice.md
+++ b/Section04/Activities/4.2-Activities/4.2.2-LocatingSliceSplice.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.2.2-LocatingSliceSplice.js`

--- a/Section04/Activities/4.2-Activities/4.2.2-LocatingSliceSplice.md
+++ b/Section04/Activities/4.2-Activities/4.2.2-LocatingSliceSplice.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.2-Activities/4.2.3-ConcatAndJoin.md
+++ b/Section04/Activities/4.2-Activities/4.2.3-ConcatAndJoin.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.2.3-Concat&Join.js`

--- a/Section04/Activities/4.2-Activities/4.2.3-ConcatAndJoin.md
+++ b/Section04/Activities/4.2-Activities/4.2.3-ConcatAndJoin.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.3-Activities/4.3.1-ForEach.md
+++ b/Section04/Activities/4.3-Activities/4.3.1-ForEach.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.3-Activities/4.3.1-ForEach.md
+++ b/Section04/Activities/4.3-Activities/4.3.1-ForEach.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.3.1-ForEach.js`

--- a/Section04/Activities/4.3-Activities/4.3.2-Map.md
+++ b/Section04/Activities/4.3-Activities/4.3.2-Map.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.3-Activities/4.3.2-Map.md
+++ b/Section04/Activities/4.3-Activities/4.3.2-Map.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.3.2-Map.js`

--- a/Section04/Activities/4.3-Activities/4.3.3-Filter.md
+++ b/Section04/Activities/4.3-Activities/4.3.3-Filter.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development` in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.3.3-Filter.js`

--- a/Section04/Activities/4.3-Activities/4.3.3-Filter.md
+++ b/Section04/Activities/4.3-Activities/4.3.3-Filter.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section04/Activities/4.3-Activities/4.3.4-Reduce.md
+++ b/Section04/Activities/4.3-Activities/4.3.4-Reduce.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type `git switch development' in your terminal
 4. Open VS Code by typing `code .`
 5. Create a new file called `4.3.4-Reduce.js`

--- a/Section04/Activities/4.3-Activities/4.3.4-Reduce.md
+++ b/Section04/Activities/4.3-Activities/4.3.4-Reduce.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section05/Activities/5.2-Activities/5.2.1-FunctionConstructors.md
+++ b/Section05/Activities/5.2-Activities/5.2.1-FunctionConstructors.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type 'git switch development' in your terminal
 4. Open VS Code by typing 'code .'
 5. Create a new file called '5.2.1-FunctionConstructors.js'

--- a/Section05/Activities/5.2-Activities/5.2.1-FunctionConstructors.md
+++ b/Section05/Activities/5.2-Activities/5.2.1-FunctionConstructors.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section05/Activities/5.2-Activities/5.2.2-MoreFunctionConstructors.md
+++ b/Section05/Activities/5.2-Activities/5.2.2-MoreFunctionConstructors.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities

--- a/Section05/Activities/5.2-Activities/5.2.2-MoreFunctionConstructors.md
+++ b/Section05/Activities/5.2-Activities/5.2.2-MoreFunctionConstructors.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type 'git switch development' in your terminal
 4. Open VS Code by typing 'code .'
 5. Create a new file called '5.2.2-MoreFunctionConstructors.js'

--- a/Section05/Activities/5.2-Activities/5.2.3-Classes.md
+++ b/Section05/Activities/5.2-Activities/5.2.3-Classes.md
@@ -1,7 +1,7 @@
 # Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
-2. Navigate to your homework Repo, then Class Activities
+2. Navigate to your ClassActivities Repo
 3. If development is not in parenthesis, type 'git switch development' in your terminal
 4. Open VS Code by typing 'code .'
 5. Create a new file called '5.2.3-Classes.js'

--- a/Section05/Activities/5.2-Activities/5.2.3-Classes.md
+++ b/Section05/Activities/5.2-Activities/5.2.3-Classes.md
@@ -1,4 +1,4 @@
-# Create a new file in your Homework Repo
+# Create a new file in your ClassActivities Repo
 
 1. Go to your terminal
 2. Navigate to your homework Repo, then Class Activities


### PR DESCRIPTION
Updated Class Activity file instructions to correctly reflect where students should navigate to for ClassActivities

In the past, we have created a single repo called "Homework" that had a "ClassActivities" folder inside of it, but now that we create 2 repos, one for "Homework" and one for "ClassActivities", the instructions need to reflect that. This merge addresses that issue.